### PR TITLE
handling relative paths on absolute keys

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var process = require('process');
 var crypto = require('crypto');
 
 module.exports = {
@@ -94,6 +95,10 @@ module.exports = {
         var fstat;
 
         try {
+          if (!path.isAbsolute(file)) {
+            file = path.resolve(process.cwd(), file);
+          }
+
           fstat = fs.statSync(file);
         } catch (ex) {
           this.removeEntry(file);
@@ -210,6 +215,10 @@ module.exports = {
        * @param entryName
        */
       removeEntry: function (entryName) {
+        if (!path.isAbsolute(entryName)) {
+          entryName = path.resolve(process.cwd(), entryName);
+        }
+
         delete normalizedEntries[entryName];
         cache.removeKey(entryName);
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-entry-cache",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Super simple cache for file metadata, useful for process that work o a given series of files and that only need to repeat the job on the changed ones since the previous run of the process",
   "repository": "jaredwray/file-entry-cache",
   "license": "MIT",

--- a/test/specs/cache.js
+++ b/test/specs/cache.js
@@ -142,6 +142,12 @@ describe('file-entry-cache', function () {
     var oFiles = cache.getUpdatedFiles(files);
 
     expect(oFiles).to.deep.equal(files);
+
+    cache.reconcile();
+
+    oFiles = cache.getUpdatedFiles(files);
+
+    expect(oFiles).to.deep.equal([]);
   });
 
   it('should return none, if no files were modified', function () {
@@ -426,6 +432,25 @@ describe('file-entry-cache', function () {
       }
 
       expect(error).to.not.equal(undefined);
+    });
+  });
+
+  describe('handling relative paths', function () {
+    it('getFileDescriptor with relative paths', function () {
+      var absoluteFile = path.resolve(__dirname, '../fixtures/', fixtureFiles[0].name);
+      var relativeFile = path.relative(process.cwd(), absoluteFile); // test/fixtures/f1.txt
+      cache = fileEntryCache.createFromFile('../fixtures/.eslintcache');
+      expect(cache.getFileDescriptor(absoluteFile).changed).to.be.true;
+      expect(cache.getFileDescriptor(relativeFile).changed).to.be.true;
+    });
+
+    it('removeEntry with relative paths', function () {
+      var absoluteFile = path.resolve(__dirname, '../fixtures/', fixtureFiles[0].name);
+      var relativeFile = path.relative(process.cwd(), absoluteFile); // test/fixtures/f1.txt
+      cache = fileEntryCache.createFromFile('../fixtures/.eslintcache');
+      cache.removeEntry(relativeFile);
+      cache.reconcile();
+      expect(cache.hasFileChanged(relativeFile)).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Working to handle relative paths when the cacheEntry.key is in an absolute path format. 